### PR TITLE
Need to use only a single thread to parse this file

### DIFF
--- a/R/spiR.R
+++ b/R/spiR.R
@@ -13,7 +13,7 @@ url <- paste0("https://warin.ca/datalake/spiR/SPI_indicator.csv")
 path <- file.path(tempdir(), "temp.csv")
 curl::curl_download(url, path)
 csv_file <- file.path(paste0(tempdir(), "/temp.csv"))
-SPI_indicator <- readr::read_csv(csv_file)
+SPI_indicator <- readr::read_csv(csv_file, num_threads = 1)
 
 # Creating the default values for the function query
 # IF an entry is missing, all the observations of this variable will be displayed


### PR DESCRIPTION
This file has some quoted fields with escaped quotes inside of them,
which causes problems when doing multi-threaded reading in readr 2.0.0.

Forcing only a single thread allows the file to be parsed as intended.